### PR TITLE
adds 'topic' as an acceptable query on the /api/articles path. Tests for errors, adds additional functionality to getAllArticles controller, renames model selectAllArticles to fetchAllArticles and adds functionality to act on query if one is provided. Adds 'topic' as a query option in endpoints.json.

### DIFF
--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,7 +1,7 @@
 const {
   fetchTopics,
   selectArticleById,
-  selectAllArticles,
+  fetchAllArticles,
   fetchCommentsByArticleId,
   insertCommentByArticleId,
   updateArticleVotes,
@@ -35,8 +35,12 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getAllArticles = (req, res, next) => {
-  selectAllArticles()
+  const { topic } = req.query;
+  fetchAllArticles(topic)
     .then((articles) => {
+      if (articles.length === 0 && topic) {
+        return res.status(404).send({ msg: "Not Found" });
+      }
       res.status(200).json({ articles });
     })
     .catch(next);

--- a/endpoints.json
+++ b/endpoints.json
@@ -4,7 +4,7 @@
   },
   "GET /api/topics": {
     "description": "serves an array of all topics",
-    "queries": [],
+    "queries": ["topic"],
     "exampleResponse": {
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }

--- a/models/models.js
+++ b/models/models.js
@@ -20,28 +20,24 @@ exports.selectArticleById = (article_id) => {
     });
 };
 
-exports.selectAllArticles = () => {
-  return db
-    .query(
-      `
-      SELECT 
-        articles.author, 
-        articles.title, 
-        articles.article_id, 
-        articles.topic, 
-        articles.created_at, 
-        articles.votes, 
-        articles.article_img_url,
-        COUNT(comments.comment_id) AS comment_count
-      FROM articles
-      LEFT JOIN comments ON articles.article_id = comments.article_id
-      GROUP BY articles.article_id
-      ORDER BY articles.created_at DESC;
-    `
-    )
-    .then(({ rows }) => {
-      return rows;
-    });
+exports.fetchAllArticles = (topic) => {
+  let queryStr = `
+    SELECT articles.*, COUNT(comments.article_id) AS comment_count 
+    FROM articles 
+    LEFT JOIN comments ON comments.article_id = articles.article_id
+  `;
+
+  const queryParams = [];
+
+  if (topic) {
+    queryStr += ` WHERE articles.topic = $1`;
+    queryParams.push(topic);
+  }
+
+  queryStr += ` GROUP BY articles.article_id 
+                ORDER BY articles.created_at DESC;`;
+
+  return db.query(queryStr, queryParams).then((result) => result.rows);
 };
 
 exports.fetchCommentsByArticleId = (article_id) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.0.0",
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "fs": "^0.0.1-security",
+        "jest-sorted": "^1.0.15",
         "pg": "^8.11.5"
       },
       "devDependencies": {
@@ -1794,11 +1795,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {
@@ -3221,6 +3225,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw=="
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -6409,9 +6418,9 @@
       }
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -7486,6 +7495,11 @@
           "dev": true
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw=="
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "supertest": "^7.0.0"
   },
   "dependencies": {
-    "dotenv": "^16.0.0",
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "fs": "^0.0.1-security",
+    "jest-sorted": "^1.0.15",
     "pg": "^8.11.5"
   },
   "jest": {


### PR DESCRIPTION
Hey there, this is my answer to Kata 11. I've added the ability to query the GET /api/articles path by topic. This filters the articles by the topic value specified in the query. If the query is omitted, the endpoint should respond with all articles.
I've updated the summary of the endpoint in endpoints.json, and added functionality to the corresponding controller and model (getAllArticles and fetchAllArticles). 
I've added new tests to my testing suite to reflect this development, and additionally added a new test to the describe block for GET /api/articles/:article_id/comments, which uses jest-sorted and .toBeSortedBy to ensure that the fetched comments from the database are sorted by date in descending order.
