### PR TITLE
modifies the model selectArticleById to use the aggregate function count() to return comment_count, adds one test to the test suite for /api/articles/:article_id, and adds comment_count to the exampleResponse in endpoints.json

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -73,6 +73,25 @@ describe("/api/articles/:article_id", () => {
         });
       });
   });
+  test("GET 200 - responds with an article object including comment_count", () => {
+    return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        expect(article).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          body: expect.any(String),
+          topic: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(String),
+        });
+      });
+  });
 
   test("GET 404 - responds with 'Not Found' for a non-existent article ID", () => {
     return request(app)

--- a/endpoints.json
+++ b/endpoints.json
@@ -38,7 +38,8 @@
         "topic": "cooking",
         "created_at": "2018-05-30T15:59:13.341Z",
         "votes": 0,
-        "article_img_url": "https://example.com/image.jpg"
+        "article_img_url": "https://example.com/image.jpg",
+        "comment_count": 6
       }
     }
   },

--- a/models/models.js
+++ b/models/models.js
@@ -7,9 +7,12 @@ exports.fetchTopics = () => {
 exports.selectArticleById = (article_id) => {
   return db
     .query(
-      `SELECT author, title, article_id, body, topic, created_at, votes, article_img_url
-         FROM articles
-         WHERE article_id = $1`,
+      `SELECT articles.author, articles.title, articles.article_id, articles.body, articles.topic, articles.created_at, articles.votes, articles.article_img_url,
+              COUNT(comments.comment_id) AS comment_count
+       FROM articles
+       LEFT JOIN comments ON comments.article_id = articles.article_id
+       WHERE articles.article_id = $1
+       GROUP BY articles.article_id;`,
       [article_id]
     )
     .then(({ rows }) => {


### PR DESCRIPTION
I've modified the model selectArticleById, which now uses the aggregate function count() to include comment_count in it's response. I've added a test for this new functionality to the test suite, and also updated endpoints.json to reflect the change.