### PR TITLE
adds logic for the /api/articles GET path to accept 'sort_by' and 'order' queries. updates endpoints.json. adds four new tests to testing suite to verify the new sorting functionality and ensure correct error handling.

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -171,6 +171,44 @@ describe("/api/articles", () => {
       });
   });
 
+  test("GET 200 - responds with articles sorted by title in ascending order", () => {
+    return request(app)
+      .get("/api/articles?sort_by=title&order=asc")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toBeSortedBy("title", { ascending: true });
+      });
+  });
+
+  test("GET 200 - responds with articles sorted by votes in descending order", () => {
+    return request(app)
+      .get("/api/articles?sort_by=votes&order=desc")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toBeSortedBy("votes", { descending: true });
+      });
+  });
+
+  test("GET 400 - responds with 'Bad Request' for invalid sort_by column", () => {
+    return request(app)
+      .get("/api/articles?sort_by=invalid_column")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad Request: Invalid sort_by column");
+      });
+  });
+
+  test("GET 400 - responds with 'Bad Request' for invalid order value", () => {
+    return request(app)
+      .get("/api/articles?order=invalid_order")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad Request: Invalid order value");
+      });
+  });
+
   test("GET 404 - responds with an error if the topic does not exist", () => {
     return request(app)
       .get("/api/articles?topic=not-a-topic")

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -36,8 +36,28 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getAllArticles = (req, res, next) => {
-  const { topic } = req.query;
-  fetchAllArticles(topic)
+  const { topic, sort_by = "created_at", order = "DESC" } = req.query;
+  const validSortByColumns = [
+    "title",
+    "author",
+    "created_at",
+    "votes",
+    "comment_count",
+  ];
+  const validOrderValues = ["ASC", "DESC"];
+
+  const sortByColumn = sort_by.toLowerCase();
+  const orderValue = order.toUpperCase();
+
+  if (sort_by && !validSortByColumns.includes(sortByColumn)) {
+    return next({ status: 400, msg: "Bad Request: Invalid sort_by column" });
+  }
+
+  if (order && !validOrderValues.includes(orderValue)) {
+    return next({ status: 400, msg: "Bad Request: Invalid order value" });
+  }
+
+  fetchAllArticles(topic, sortByColumn, orderValue)
     .then((articles) => {
       if (articles.length === 0 && topic) {
         return checkTopicExists(topic).then((exists) => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": [],
+    "queries": ["sort_by", "order", "topic"],
     "exampleResponse": {
       "articles": [
         {

--- a/models/models.js
+++ b/models/models.js
@@ -23,7 +23,7 @@ exports.selectArticleById = (article_id) => {
     });
 };
 
-exports.fetchAllArticles = (topic) => {
+exports.fetchAllArticles = (topic, sort_by = "created_at", order = "DESC") => {
   let queryStr = `
     SELECT articles.*, COUNT(comments.article_id) ::INT AS comment_count 
     FROM articles 
@@ -38,7 +38,7 @@ exports.fetchAllArticles = (topic) => {
   }
 
   queryStr += ` GROUP BY articles.article_id 
-                ORDER BY articles.created_at DESC;`;
+                ORDER BY ${sort_by} ${order};`;
 
   return db.query(queryStr, queryParams).then((result) => result.rows);
 };


### PR DESCRIPTION
Here I've added the logic for the /api/articles GET path to now accept 'sort_by' and 'order' queries, to allow the articles to be sorted by any valid column (defaults to the created_at date), and in either ascending or descending order (defaults to descending). 

I've updated endpoints.json to reflect this development, and also added four new tests to testing suite; verifying that the new sorting functionality behaves as expected, and ensuring correct error handling.